### PR TITLE
fix: cannot use duckdb layer outside the us-east-1 region

### DIFF
--- a/src/constructs/api/index.ts
+++ b/src/constructs/api/index.ts
@@ -1,5 +1,5 @@
 import * as path from 'node:path';
-import { RemovalPolicy, Size, Duration } from 'aws-cdk-lib';
+import { RemovalPolicy, Size, Duration, Stack } from 'aws-cdk-lib';
 import * as apigateway from 'aws-cdk-lib/aws-apigateway';
 import * as cognito from 'aws-cdk-lib/aws-cognito';
 import * as iam from 'aws-cdk-lib/aws-iam';
@@ -85,9 +85,14 @@ export class Api extends Construct {
       }),
     );
     duckdbBucket.grantReadWrite(duckdbHandler);
+
+    // uses duckdb-nodejs-layer
+    // https://github.com/tobilg/duckdb-nodejs-layer
+    const layerArn = `arn:aws:lambda:${Stack.of(this).region}:041475135427:layer:duckdb-nodejs-x86:14`;
     duckdbHandler.addLayers(lambda.LayerVersion.fromLayerVersionArn(
-      this, 'DuckdbLayer', 'arn:aws:lambda:us-east-1:041475135427:layer:duckdb-nodejs-x86:14',
+      this, 'DuckdbLayer', layerArn,
     ));
+
     const duckdb = resource.addResource('duckdb');
     duckdb.addMethod(
       'POST',

--- a/test/integ.cloud-duck.js.snapshot/TestStack.assets.json
+++ b/test/integ.cloud-duck.js.snapshot/TestStack.assets.json
@@ -79,7 +79,7 @@
         }
       }
     },
-    "4f1e5685003edb17452b2a8bf74fc092d3b4ae2999f6f55ed2613e0c6f168b29": {
+    "cce4152644f7d6a302ae937668c101fad41000701fe6b64b7ba79b57010efa9d": {
       "source": {
         "path": "TestStack.template.json",
         "packaging": "file"
@@ -87,7 +87,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "4f1e5685003edb17452b2a8bf74fc092d3b4ae2999f6f55ed2613e0c6f168b29.json",
+          "objectKey": "cce4152644f7d6a302ae937668c101fad41000701fe6b64b7ba79b57010efa9d.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ.cloud-duck.js.snapshot/TestStack.template.json
+++ b/test/integ.cloud-duck.js.snapshot/TestStack.template.json
@@ -813,7 +813,18 @@
     },
     "Handler": "index.handler",
     "Layers": [
-     "arn:aws:lambda:us-east-1:041475135427:layer:duckdb-nodejs-x86:14"
+     {
+      "Fn::Join": [
+       "",
+       [
+        "arn:aws:lambda:",
+        {
+         "Ref": "AWS::Region"
+        },
+        ":041475135427:layer:duckdb-nodejs-x86:14"
+       ]
+      ]
+     }
     ],
     "MemorySize": 2048,
     "Role": {

--- a/test/integ.cloud-duck.js.snapshot/manifest.json
+++ b/test/integ.cloud-duck.js.snapshot/manifest.json
@@ -19,7 +19,7 @@
         "notificationArns": [],
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/4f1e5685003edb17452b2a8bf74fc092d3b4ae2999f6f55ed2613e0c6f168b29.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/cce4152644f7d6a302ae937668c101fad41000701fe6b64b7ba79b57010efa9d.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/test/integ.cloud-duck.js.snapshot/tree.json
+++ b/test/integ.cloud-duck.js.snapshot/tree.json
@@ -1222,7 +1222,18 @@
                             },
                             "handler": "index.handler",
                             "layers": [
-                              "arn:aws:lambda:us-east-1:041475135427:layer:duckdb-nodejs-x86:14"
+                              {
+                                "Fn::Join": [
+                                  "",
+                                  [
+                                    "arn:aws:lambda:",
+                                    {
+                                      "Ref": "AWS::Region"
+                                    },
+                                    ":041475135427:layer:duckdb-nodejs-x86:14"
+                                  ]
+                                ]
+                              }
                             ],
                             "memorySize": 2048,
                             "role": {


### PR DESCRIPTION
Fixes #10 